### PR TITLE
Fix lxml html clean import error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,8 @@ WORKDIR /app
 # Install system dependencies
 RUN apt-get update && apt-get install -y \
     gcc \
+    libxml2-dev \
+    libxslt-dev \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements first for better caching

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ sqlalchemy>=2.0.0
 flask-sqlalchemy>=3.0.0
 feedparser>=6.0.0
 newspaper3k>=0.2.8
+lxml[html_clean]>=4.9.0
 gunicorn>=21.0.0
 openai>=1.3.0
 tiktoken>=0.5.0


### PR DESCRIPTION
Add `lxml[html_clean]` and system dependencies to resolve `ImportError` for `lxml.html.clean`.

---
<a href="https://cursor.com/background-agent?bcId=bc-8cceef48-240f-4bac-a487-38afde9927c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8cceef48-240f-4bac-a487-38afde9927c7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

