### PR TITLE
Fix post serialization for dashboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -45,13 +45,28 @@ logger = logging.getLogger(__name__)
 def index():
     """Dashboard view"""
     recent_posts = Post.query.order_by(Post.created_at.desc()).limit(10).all()
+    # Convert Post objects to dictionaries for JSON serialization
+    posts_data = [{
+        'id': post.id,
+        'title': post.title,
+        'content': post.content,
+        'url': post.url,
+        'image_url': post.image_url,
+        'facebook_post_id': post.facebook_post_id,
+        'status': post.status,
+        'source': post.source,
+        'created_at': post.created_at.isoformat() if post.created_at else None,
+        'posted_at': post.posted_at.isoformat() if post.posted_at else None,
+        'error_message': post.error_message
+    } for post in recent_posts]
+    
     settings = Settings.query.first()
     if not settings:
         settings = Settings()
         db.session.add(settings)
         db.session.commit()
     
-    return render_template('dashboard.html', posts=recent_posts, settings=settings)
+    return render_template('dashboard.html', posts=posts_data, settings=settings)
 
 @app.route('/settings', methods=['GET', 'POST'])
 def settings():

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -182,11 +182,11 @@
                                     </td>
                                     <td>{{ post.source or 'Unknown' }}</td>
                                     <td>
-                                        <small>{{ post.created_at.strftime('%m/%d %H:%M') }}</small>
+                                        <small class="date-display" data-date="{{ post.created_at }}">{{ post.created_at }}</small>
                                     </td>
                                     <td>
                                         {% if post.posted_at %}
-                                            <small>{{ post.posted_at.strftime('%m/%d %H:%M') }}</small>
+                                            <small class="date-display" data-date="{{ post.posted_at }}">{{ post.posted_at }}</small>
                                         {% else %}
                                             <small class="text-muted">Not posted</small>
                                         {% endif %}
@@ -254,6 +254,7 @@
 // Load dashboard statistics
 document.addEventListener('DOMContentLoaded', function() {
     loadDashboardStats();
+    formatDates();
     
     // Initialize tooltips
     var tooltipTriggerList = [].slice.call(document.querySelectorAll('[data-bs-toggle="tooltip"]'));
@@ -261,6 +262,29 @@ document.addEventListener('DOMContentLoaded', function() {
         return new bootstrap.Tooltip(tooltipTriggerEl);
     });
 });
+
+function formatDates() {
+    // Format all date displays
+    document.querySelectorAll('.date-display').forEach(function(element) {
+        const dateString = element.getAttribute('data-date');
+        if (dateString && dateString !== 'None') {
+            try {
+                const date = new Date(dateString);
+                if (!isNaN(date.getTime())) {
+                    element.textContent = date.toLocaleDateString('en-US', {
+                        month: '2-digit',
+                        day: '2-digit',
+                        hour: '2-digit',
+                        minute: '2-digit',
+                        hour12: false
+                    });
+                }
+            } catch (e) {
+                console.error('Error formatting date:', dateString, e);
+            }
+        }
+    });
+}
 
 function loadDashboardStats() {
     fetch('/api/posts')


### PR DESCRIPTION
Fixes `TypeError: Object of type Post is not JSON serializable` by converting Post objects to dictionaries for template rendering.

The `Post` SQLAlchemy model instances were passed directly to the Jinja2 `tojson` filter in `dashboard.html`. SQLAlchemy objects are not inherently JSON serializable, leading to a `TypeError`. The solution involves serializing `Post` objects into dictionaries with ISO-formatted datetime strings in `app.py` before passing them to the template. The template then uses JavaScript to format these ISO strings for display.

---
<a href="https://cursor.com/background-agent?bcId=bc-6b3fc585-f743-4e40-9922-9c9e20778a18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6b3fc585-f743-4e40-9922-9c9e20778a18">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

